### PR TITLE
Fix CodeMirror focus issue.

### DIFF
--- a/src/components/DraggableCard.tsx
+++ b/src/components/DraggableCard.tsx
@@ -26,7 +26,7 @@ export default class DraggableCard extends Preact.Component<Props> {
     } = this.props
 
     return (
-      <Draggable defaultPosition={{ x, y }} onStart={this.start} z={z}>
+      <Draggable defaultPosition={{ x, y }} onStart={this.start} z={z} enableUserSelectHack={false}>
         <Card>{children}</Card>
       </Draggable>
     )


### PR DESCRIPTION
The problem with CodeMirror not accepting input stems from Draggable removing all selections in the drag end handler - which fires when you click into the text editor. This breaks CodeMirror even though it looks fine because it renders its own cursor.

The `enableUserSelectHack` prop is intended to prevent text in the document from being selected while dragging. Disabling it is ok in our case because the default chrome app css applies `user-select: none` to `body`.

Actual selection removal happens here: https://github.com/inkandswitch/capstone/blob/97044ffd66de4a7ca5d06300b4eab5f972113abf/src/draggable/domFns.ts#L191



