### PR TITLE
Adding visual queues and behavior for card editing focus

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -14,7 +14,6 @@ interface CardModel {
   y: number
   z: number
   url: string
-  isFocused: boolean
 }
 
 export interface Model {
@@ -48,18 +47,20 @@ export default class Board extends Widget<Model, Props> {
         onDblClick={this.onDblClick}
         ref={(el: HTMLElement) => (this.boardEl = el)}>
         {cards.map((card, idx) => {
-          const isFocused = card.url === locallyFocusedCardURL
-          const key = `${idx}-${isFocused}`
           return (
             <DraggableCard
-              key={key}
+              key={idx}
               index={idx}
               card={card}
               onPinchEnd={this.props.onNavigate}
               onDragStart={this.onDragStart}
               onDragStop={this.onDragStop}
               onTap={this.onTapCard}>
-              <Content mode="embed" url={card.url} isFocused={isFocused} />
+              <Content
+                mode="embed"
+                url={card.url}
+                isFocused={card.url === locallyFocusedCardURL}
+              />
             </DraggableCard>
           )
         })}

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -60,7 +60,6 @@ export default class Content extends Preact.Component<Props & unknown> {
   }
 
   render() {
-    console.log("content render")
     const { mode } = this.props
     const { url, type } = Link.parse(this.props.url)
     const Widget = Content.find(type)

--- a/src/components/DraggableCard.tsx
+++ b/src/components/DraggableCard.tsx
@@ -23,9 +23,7 @@ export interface Props {
 
 export default class DraggableCard extends Preact.Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
-    return (
-      this.props.card !== nextProps.card
-    )
+    return this.props.card !== nextProps.card
   }
 
   render() {

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -18,7 +18,6 @@ export default class Text extends Widget<Model> {
   }
 
   show({ content }: Model) {
-    console.log("text render " + (this.doc && this.doc.url))
     return (
       <TextEditor
         content={content.join("")}

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -48,8 +48,7 @@ export default class TextEditor extends Preact.Component<Props, State> {
     this.codeMirror.on("change", this.onCodeMirrorChange)
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    console.log("component will receive props")
+  componentWillReceiveProps = (nextProps: Props) => {
     if (!this.codeMirror) return
 
     if (nextProps.content !== this.props.content) {
@@ -110,9 +109,6 @@ export default class TextEditor extends Preact.Component<Props, State> {
     if (!this.codeMirror) return
     if (isFocused && !this.codeMirror.hasFocus()) {
       this.codeMirror.focus()
-    } else if (!isFocused && this.codeMirror.hasFocus()) {
-      console.log("clear focus")
-      this.codeMirror.getInputField().blur()
     }
   }
 


### PR DESCRIPTION
- Adds an overlay between board content and currently edited card (for now just 15% black, will get properly styled when Gökcen designs)
- Clamps the area for dragging cards to a 15px padding around the board
- Using Hammer's onTap to assume focus of a card
- Exiting focus mode via tapping anywhere on the overlay

There's still some buggy behavior particularly with touch on the Pixelbook.

Next steps:
- exit edit mode when hiding keyboard (and don't exit edit mode via tap on overlay)
- prevent dragging of currently edited card  (to support text selection)
- sometimes dragging a card gives CodeMirror focus and makes the keyboard appear, fix this
- super-short tap on card doesn't give the card focus, fix this