### PR TITLE
Full-screen the app on open/reload

### DIFF
--- a/src/entry.chrome.ts
+++ b/src/entry.chrome.ts
@@ -1,17 +1,28 @@
 // This should be a real typescript file but we're having trouble
 // finding the AppWindow type which has a contentWindow on it.
-let commandWindow: chrome.app.window.AppWindow
+let mainWindow: chrome.app.window.AppWindow
 
 chrome.app.runtime.onLaunched.addListener(() => {
-  if (commandWindow && !commandWindow.contentWindow.closed) {
-    commandWindow.focus()
-  } else {
-    chrome.app.window.create(
-      "index.html",
-      { id: "mainwin", innerBounds: { width: 800, height: 609, left: 0 } },
-      win => {
-        commandWindow = win
+  chrome.app.window.create(
+    "index.html",
+    {
+      id: "main",
+      frame: "chrome",
+      state: "fullscreen",
+      resizable: true,
+      outerBounds: {
+        // Half-screen default for development
+        // Press "square" key (F3) to toggle
+        top: 0,
+        left: 0,
+        width: screen.width / 2,
+        height: screen.height,
       },
-    )
-  }
+    },
+    win => {
+      mainWindow = win
+      win.fullscreen()
+      win.show(true) // Passing focused: true
+    },
+  )
 })


### PR DESCRIPTION
Quick patch to full-screen the app when it's opened, re-opened, or reloaded.

Use F3 key (square thing) to toggle full-screen after it's loaded. We'll probably disable this eventually with kiosk mode, but for development I'm thinking full-screen-by-default is good.

The window will still remember your non-full-screen sizing, but it defaults to taking up the left side so there's room for the debugger.