### PR TITLE
Allow the automatic switch to fullscreen to be disabled during development

### DIFF
--- a/src/entry.chrome.ts
+++ b/src/entry.chrome.ts
@@ -22,7 +22,11 @@ chrome.app.runtime.onLaunched.addListener(() => {
     },
     win => {
       mainWindow = win
-      win.fullscreen()
+      chrome.storage.local.get(["disableFullscreen"], result => {
+        if (!result.disableFullscreen) {
+          win.fullscreen()
+        }
+      })
       win.show(true) // Passing focused: true
     },
   )


### PR DESCRIPTION
It's quite annoying during development when the app switches to full screen every time you reload. This patch allows the full-screen mode to be disabled by running the following in the console of the app:

```js
chrome.storage.local.set({ "disableFullscreen": true })
```