### PR TITLE
Text card auto height

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -7,7 +7,7 @@ import * as Reify from "../data/Reify"
 import * as UUID from "../data/UUID"
 import VirtualKeyboard from "./VirtualKeyboard"
 import { AnyDoc, Doc } from "automerge"
-import { CARD_HEIGHT, CARD_WIDTH } from "./Card"
+import { CARD_WIDTH } from "./Card"
 import { clamp } from "lodash"
 import StrokeRecognizer, { Stroke } from "./StrokeRecognizer"
 
@@ -173,7 +173,7 @@ export default class Board extends Widget<Model, Props> {
   onStroke = (stroke: Stroke) => {
     switch (stroke.name) {
       case "box":
-        this.createCard("Text", stroke.center.x, stroke.center.y)
+        this.createCard("Text", stroke.center.x, stroke.bounds.top)
     }
   }
 
@@ -189,9 +189,9 @@ export default class Board extends Widget<Model, Props> {
     if (!this.boardEl) return
 
     const maxX = this.boardEl.clientWidth - CARD_WIDTH - 2 * BOARD_PADDING
-    const maxY = this.boardEl.clientHeight - CARD_HEIGHT - 2 * BOARD_PADDING
+    const maxY = this.boardEl.clientHeight - 2 * BOARD_PADDING
     const cardX = clamp(x - CARD_WIDTH / 2, 0, maxX)
-    const cardY = clamp(y - CARD_HEIGHT / 2, 0, maxY)
+    const cardY = clamp(y, 0, maxY)
 
     const url = await Content.create(type)
     this.change(doc => {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,7 +1,6 @@
 import * as Preact from "preact"
 
 export const CARD_WIDTH = 398
-export const CARD_HEIGHT = 398
 
 export default class Card extends Preact.Component {
   render() {
@@ -17,7 +16,6 @@ export default class Card extends Preact.Component {
 const style = {
   Card: {
     width: CARD_WIDTH,
-    height: CARD_HEIGHT,
     fontSize: 11,
     lineHeight: 1.4,
     backgroundColor: "white",

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -7,7 +7,8 @@
   font-family: Arial, Helvetica, sans-serif;
   color: gray;
   direction: ltr;
-  height: 100%;
+  max-height: 100%;
+  height: auto;
 }
 
 /* CodeMirror defines "overflow: scroll !important" on .CodeMirror-scroll.
@@ -18,4 +19,5 @@
  */
 .CodeMirror .CodeMirror-scroll {
   touch-action: none;
+  max-height: 500px;
 }


### PR DESCRIPTION
Text cards now resize to the height of their contents with a max of 500px.

There's some strange behavior when the card is one line tall: the screen gets dimmer for some reason. The same thing happens with a taller card if you start dragging it off the screen while it's focused.
Test it out, maybe it's just my machine.