### PR TITLE
Prevent hammer listener leaks

### DIFF
--- a/src/components/Pen.tsx
+++ b/src/components/Pen.tsx
@@ -40,6 +40,11 @@ export default class Pen extends Handler<Props> {
     this.hammer.on("panend", this.handle("onPanEnd"))
   }
 
+  componentWillUnmount() {
+    this.hammer.off("doubletap panmove panend")
+    this.hammer.destroy()
+  }
+
   filter(event: PenEvent) {
     return event.pointerType === "pen"
   }

--- a/src/components/Touch.tsx
+++ b/src/components/Touch.tsx
@@ -64,6 +64,11 @@ export default class Touch extends Handler<Props> {
     this.hammer.on("threeFingerSwipeUp", this.handle("onThreeFingerSwipeUp"))
   }
 
+  componentWillUnmount() {
+    this.hammer.off("pinchend tap threeFingerSwipeDown threeFingerSwipeUp")
+    this.hammer.destroy()
+  }
+
   filter(event: TouchEvent) {
     return event.pointerType !== "pen"
   }


### PR DESCRIPTION
Remove hammer event listeners and destroys the hammer instance on  unmount. Prevents listener leaks and duplicate events.