### PR TITLE
WIP - ease stroke recognition

### DIFF
--- a/src/components/ArchiveItem.tsx
+++ b/src/components/ArchiveItem.tsx
@@ -1,6 +1,6 @@
 import * as Preact from "preact"
 import Content from "./Content"
-import StrokeRecognizer from "./StrokeRecognizer"
+import StrokeRecognizer, { Stroke } from "./StrokeRecognizer"
 
 interface ArchiveItemProps {
   url: string
@@ -12,7 +12,7 @@ export default class ArchiveItem extends Preact.Component<ArchiveItemProps> {
   render() {
     const { url, isSelected } = this.props
     return (
-      <StrokeRecognizer onStroke={this.onStroke} only={["uparrow"]}>
+      <StrokeRecognizer onStroke={this.onStroke}>
         <div style={style.Item}>
           <div style={style.ItemContent}>
             <Content mode="preview" url={url} />
@@ -22,8 +22,9 @@ export default class ArchiveItem extends Preact.Component<ArchiveItemProps> {
     )
   }
 
-  onStroke = () => {
-    this.props.onStroke(this.props.url)
+  onStroke = (stroke: Stroke) => {
+    if (stroke.name === "uparrow") this.props.onStroke(this.props.url)
+    else console.log(stroke.name)
   }
 }
 

--- a/src/components/StrokeRecognizer.tsx
+++ b/src/components/StrokeRecognizer.tsx
@@ -56,15 +56,24 @@ DEFAULT_RECOGNIZER.AddGesture("downarrow", [
 ])
 
 DEFAULT_RECOGNIZER.AddGesture("uparrow", [
-  new $P.Point(0, 1, 0),
-  new $P.Point(1, 0, 0),
-  new $P.Point(2, 1, 0),
+  new $P.Point(0, 1, 1),
+  new $P.Point(1, 0, 1),
+  new $P.Point(2, 1, 1),
+])
+
+DEFAULT_RECOGNIZER.AddGesture("horizontalLine", [
+  new $P.Point(0, 0, 1),
+  new $P.Point(1, 0, 1),
+])
+DEFAULT_RECOGNIZER.AddGesture("verticalLine", [
+  new $P.Point(0, 0, 1),
+  new $P.Point(0, 1, 1),
 ])
 
 export default class StrokeRecognizer extends Preact.Component<Props> {
   static defaultProps = {
     delay: 200,
-    maxScore: 6,
+    maxScore: 8,
   }
 
   recognizer: $P.Recognizer = DEFAULT_RECOGNIZER


### PR DESCRIPTION
@julsh this is an attempt at easing gesture recognition - and archive uparrow in particular. 

It works by adding a few simple gestures (vertical and horizontal line), includes all gestures as recognition possibilities, and relaxes the scoring requirement (making it easier to recognize *any* gesture). This makes the recognizer more likely to recognize some gesture and the additional gestures help to reduce false positives for uparrow. Recognizing multiple gestures means we need to check for the correct gesture in the `onStroke` handler, but I could imagine an implementation where the `only` prop to `StrokeRecognizer` restricts which gestures invoke the callback (but not which gestures influence the recognizer).

Feel free to discard!