### PR TITLE
remove timeout on initial listener for new windows

### DIFF
--- a/src/entry.chrome.ts
+++ b/src/entry.chrome.ts
@@ -3,36 +3,34 @@ import StoreComms from "./data/StoreComms"
 
 let mainWindow: chrome.app.window.AppWindow
 
-setTimeout(() => {
-  chrome.app.runtime.onLaunched.addListener(() => {
-    chrome.app.window.create(
-      "index.html",
-      {
-        id: "main",
-        frame: "chrome",
-        state: "fullscreen",
-        resizable: true,
-        outerBounds: {
-          // Half-screen default for development
-          // Press "square" key (F3) to toggle
-          top: 0,
-          left: 0,
-          width: screen.width / 2,
-          height: screen.height,
-        },
+chrome.app.runtime.onLaunched.addListener(() => {
+  chrome.app.window.create(
+    "index.html",
+    {
+      id: "main",
+      frame: "chrome",
+      state: "fullscreen",
+      resizable: true,
+      outerBounds: {
+        // Half-screen default for development
+        // Press "square" key (F3) to toggle
+        top: 0,
+        left: 0,
+        width: screen.width / 2,
+        height: screen.height,
       },
-      win => {
-        mainWindow = win
-        chrome.storage.local.get(["disableFullscreen"], result => {
-          if (!result.disableFullscreen) {
-            win.fullscreen()
-          }
-        })
-        win.show(true) // Passing focused: true
-      },
-    )
-  })
-}, 1000)
+    },
+    win => {
+      mainWindow = win
+      chrome.storage.local.get(["disableFullscreen"], result => {
+        if (!result.disableFullscreen) {
+          win.fullscreen()
+        }
+      })
+      win.show(true) // Passing focused: true
+    },
+  )
+})
 
 let comms = new StoreComms()
 


### PR DESCRIPTION
This patch just removes the timeout from adding the listener to the new window -- based on my experimenting I think this is why sometimes the Capstone window doesn't "pop" on initial install. 

I think the event is expiring with no listeners and then the listener is added 1s later.