### PR TITLE
Always broadcast to the Workspace.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -29,6 +29,7 @@ export default class App extends Preact.Component<{}, State> {
     let shelfUrl = Content.create("Shelf")
 
     Content.create("Workspace").then(workspaceUrl => {
+      Content.workspaceUrl = workspaceUrl
       let workspaceUpdateFunction = Content.open<Workspace.Model>(
         workspaceUrl,
         (workspaceDoc: any) => {
@@ -38,11 +39,12 @@ export default class App extends Preact.Component<{}, State> {
               // by jeff's RxJS patch
               // what we want here is sort of a .once('update') style callback,
               // probably from create() itself
-              if (workspaceDoc.archiveUrl) return
-              workspaceDoc.currentUrl = boardUrl
-              workspaceDoc.archiveUrl = archiveUrl
-              workspaceDoc.shelfUrl = shelfUrl
-              workspaceUpdateFunction(workspaceDoc)
+              if (!workspaceDoc.archiveUrl) {
+                workspaceDoc.currentUrl = boardUrl
+                workspaceDoc.archiveUrl = archiveUrl
+                workspaceDoc.shelfUrl = shelfUrl
+                workspaceUpdateFunction(workspaceDoc)
+              }
               this.setState({ url: workspaceUrl })
               chrome.storage.local.set({ workspaceUrl })
             },
@@ -59,6 +61,7 @@ export default class App extends Preact.Component<{}, State> {
       if (val.workspaceUrl == undefined) {
         this.initWorkspace()
       } else {
+        Content.workspaceUrl = val.workspaceUrl
         this.setState({ url: val.workspaceUrl })
       }
     })

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -129,6 +129,7 @@ export default class Content extends Preact.Component<Props & unknown> {
   static documentCache: { [id: string]: Doc<any> } = {}
 
   static store: Store
+  static workspaceUrl: string
 
   /// Registry:
 
@@ -170,7 +171,7 @@ export default class Content extends Preact.Component<Props & unknown> {
   }
 
   static send(message: Message & WithSender) {
-    message.to = message.to || Content.getParent(message.from)
+    message.to = message.to || Content.workspaceUrl
     if (!isFullyFormed(message)) {
       return
     }
@@ -179,50 +180,11 @@ export default class Content extends Preact.Component<Props & unknown> {
     recipient.receive(message)
   }
 
-  // Component-ordered Document Hierarchy
-  // ====================================
-  static setParent(childUrl: string, parentUrl: string) {
-    Content.ancestorMap[childUrl] = parentUrl
-  }
-
-  static getParent(childUrl: string): string | undefined {
-    return this.ancestorMap[childUrl]
-  }
-
-  static clearParent(childUrl: string) {
-    delete this.ancestorMap[childUrl]
-  }
-
   // Component
   // =========
 
   get registry() {
     return Content.widgetRegistry
-  }
-
-  getChildContext() {
-    return { parentUrl: this.props.url }
-  }
-
-  componentDidMount() {
-    if (this.context.parentUrl) {
-      Content.setParent(this.props.url, this.context.parentUrl)
-    }
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.url !== this.props.url) {
-      Content.clearParent(this.props.url)
-      if (this.context.parentUrl) {
-        Content.setParent(nextProps.url, this.context.parentUrl)
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.context.parentUrl) {
-      Content.clearParent(this.props.url)
-    }
   }
 
   render() {


### PR DESCRIPTION
Get rid of the `ancestorMap` and always broadcast to the workspace instead. This is a pre-req for multiple boards.

Eventually we may need to come up with a more flexible broadcast, but don't currently have the use case.