### PR TITLE
Check both keys and values for doclinks when Prefetching

### DIFF
--- a/src/logic/Traverse.ts
+++ b/src/logic/Traverse.ts
@@ -22,7 +22,7 @@ export function iterativeDFS<T>(root: any, select: SelectFn<T>): T[] {
     }
     const obj = stack.pop()
     if (isPlainObject(obj)) {
-      Object.values(obj).forEach((val: any) => stack.push(val))
+      Object.entries(obj).forEach((entry: any) => stack.push(entry))
     } else if (obj.forEach) {
       obj.forEach((val: any) => stack.push(val))
     } else if (select(obj)) {


### PR DESCRIPTION
Prefetch docs if the doc ids are being used as keys in an object.