### PR TITLE
Command feedback tweaks

### DIFF
--- a/src/components/CommandFeedback.tsx
+++ b/src/components/CommandFeedback.tsx
@@ -28,7 +28,12 @@ interface FeedbackItemProps {
 }
 
 class FeedbackItem extends Preact.Component<FeedbackItemProps> {
+  hasEntered = false
   onAnimationEnd = (event: AnimationEvent) => {
+    if (!this.hasEntered) {
+      this.hasEntered = true
+      return
+    }
     this.props.animationEnded(this.props.feedbackData.id)
   }
 

--- a/src/components/css/Card.css
+++ b/src/components/css/Card.css
@@ -10,10 +10,11 @@
   grid-template-rows: auto;
   grid-template-columns: auto;
   transition-property: transform opacity;
-  transition-duration: 0.5s;
+  transition-timing-function: ease-in;
+  transition-duration: 100ms;
 }
 
 .exiting .Card {
-  transform: scale(0.3);
-  opacity: 0;
+  transform: scale(0);
+  opacity: 0.1;
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -37,40 +37,49 @@
 }
 
 .CommandFeedback {
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.5);
   height: 30px;
   position: fixed;
-  border-radius: 12px;
-  padding: 4px 8px;
-  left: 50%;
-  transform: translateX(-50%);
+  border-radius: 15px;
+  padding: 5px 12px;
+  opacity: 1;
   pointer-events: none;
   z-index: 3;
-  animation: fadeinout 1.5s linear 1 forwards;
+  transition-property: transform opacity;
+  transition-duration: 0.5s;
+  animation-name: fadein, fadeout;
+  animation-duration: 300ms, 300ms;
+  animation-delay: 0ms, 600ms;
+  animation-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
+  animation-fill-mode: forwards, forwards;
 }
 
 .CommandFeedback__Text {
   display: inline-block;
+  text-align: center;
   vertical-align: middle;
   color: white;
   font-size: 12pt;
 }
 
-@keyframes fadeinout {
+@keyframes fadein {
   0% {
     opacity: 0;
-    transform: scale(0.2);
-  }
-  20% {
-    opacity: 1;
-    transform: scale(1.05);
-  }
-  90% {
-    opacity: 1;
-    transform: scale(1);
+    transform: translateX(-50%) translateY(-50%) scale(0);
   }
   100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-50%) scale(1);
+  }
+}
+
+@keyframes fadeout {
+  0% {
+    transform: translateX(-50%) translateY(-50%) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(-50%) scale(1);
     opacity: 0;
-    transform: scale(0);
   }
 }


### PR DESCRIPTION
- Adjust appearance based on Gökcens specs
- Tweak animation properties (duration, timing curve etc) of command feedback and card delete 
- Display command feedback at card center instead of drawn glyph center

Open issues: (tbd in separate PR)
- When targetting a card close to the edge, the command feedback line-wraps the text and the text overflows the command feedback box, which looks broken. Might need to define a relative min/max position to ensure that no line breaking occurs 