### PR TITLE
Store global mode property on GPS, don't send events to draggable card if in inking mode

### DIFF
--- a/src/components/DraggableCard.tsx
+++ b/src/components/DraggableCard.tsx
@@ -24,6 +24,7 @@ export interface Props {
 export default class DraggableCard extends React.Component<Props> {
   events$ = GPS.stream().pipe(
     RxOps.map(GPS.onlyPen),
+    RxOps.filter(GPS.ifNotInking),
     RxOps.filter(GPS.ifNotEmpty),
     RxOps.map(GPS.toAnyPointer),
   )

--- a/src/components/Ink.tsx
+++ b/src/components/Ink.tsx
@@ -195,8 +195,11 @@ export default class Ink extends React.Component<Props, State> {
   onStrokeTypeChange = (strokeType?: StrokeType) => {
     if (this.state.strokeType === strokeType) return
     if (strokeType == undefined) {
+      GPS.setInteractionMode(GPS.InteractionMode.default)
       this.shouldRedrawDryInk = true
       this.inkStroke()
+    } else {
+      GPS.setInteractionMode(GPS.InteractionMode.inking)
     }
     this.setState({ strokeType })
   }

--- a/src/logic/GPS.ts
+++ b/src/logic/GPS.ts
@@ -3,6 +3,11 @@ import * as RxOps from "rxjs/operators"
 import { pickBy } from "lodash"
 import * as GPS from "../logic/GPS"
 
+export enum InteractionMode {
+  default,
+  inking,
+}
+
 export type PointerSnapshot = { [pointerId: string]: PointerEvent }
 export type Pointer = {
   pointerId: number
@@ -15,6 +20,7 @@ export type Pointer = {
 
 // TODO: clean this up.
 let events$ = new Rx.Observable<PointerSnapshot>()
+let interactionMode = InteractionMode.default
 
 // Connect a stream of PointerEvents to the GPS.
 export function connectInput(input$: Rx.Observable<PointerEvent>) {
@@ -30,6 +36,11 @@ export function connectInput(input$: Rx.Observable<PointerEvent>) {
       return snapshot
     }, {}),
   )
+}
+
+export function setInteractionMode(mode: InteractionMode) {
+  if (interactionMode == mode) return
+  interactionMode = mode
 }
 
 // Expose a stream of PointerSnapshots
@@ -54,6 +65,9 @@ export const toPointers = (s: PointerSnapshot) => Object.values(s)
 
 // Get an arbitrary pointer from the snapshot.
 export const toAnyPointer = (s: PointerSnapshot) => toPointers(s)[0]
+
+export const ifNotInking = (s: PointerSnapshot) =>
+  interactionMode != InteractionMode.inking
 
 // Filter the snapshot so only pointers on a target remain.
 export const onlyOnTarget = (target: HTMLElement) => (


### PR DESCRIPTION
This is a quick-fix for the bug we saw where inking on a card also moves the card at the same time. Might wanna put some more thought soon into how the mode system should work and tie in with the event flow.