### PR TITLE
Draw destination-out instead of source-over for eraser

### DIFF
--- a/src/components/Ink.tsx
+++ b/src/components/Ink.tsx
@@ -67,7 +67,7 @@ const StrokeSettings: { [st: number]: StrokeSettings } = {
     lineWidth: 16,
   },
   [StrokeType.erase]: {
-    globalCompositeOperation: "source-over",
+    globalCompositeOperation: "destination-out",
     strokeStyle: "white",
     lineCap: "round",
     lineJoin: "round",


### PR DESCRIPTION
removes that white-drawing nonesense for eraser. 
read up on the `globalCompositeOperation` options, pretty good stuff :)