### PR TITLE
make sidecar uploads go straight to root board

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -33,6 +33,7 @@ export default class App extends React.Component<Props, State> {
     const workspaceUrl = Content.create("Workspace")
 
     Content.workspaceUrl = workspaceUrl
+    Content.rootBoardUrl = rootBoardUrl
 
     // Initialize the workspace
     Content.once<Workspace.Model>(workspaceUrl, (change: Function) => {
@@ -60,13 +61,17 @@ export default class App extends React.Component<Props, State> {
         workspaceUrl,
         (workspace: Doc<Workspace.Model>) => {
           Content.workspaceUrl = workspaceUrl
+          Content.rootBoardUrl = workspace.rootUrl
+
           this.setState({ url: workspaceUrl })
         },
       )
     }
 
     // subscribe to the web clipper for messages about new content
-    Content.store.clipper().subscribe((message = {}) => {
+    Content.store.clipper().subscribe(message => {
+      if (!message) return
+
       const { contentType, content } = message
 
       switch (contentType) {

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -129,6 +129,7 @@ export default class Content extends React.Component<Props & unknown> {
 
   static store: Store
   static workspaceUrl: string
+  static rootBoardUrl: string
 
   /// Registry:
 

--- a/src/components/Shelf.tsx
+++ b/src/components/Shelf.tsx
@@ -3,7 +3,7 @@ import * as Reify from "../data/Reify"
 import * as Widget from "./Widget"
 import { AnyDoc } from "automerge/frontend"
 import ShelfCard from "./ShelfCard"
-import { DocumentActor, Message, FullyFormedMessage } from "./Content"
+import Content, { DocumentActor, Message, FullyFormedMessage } from "./Content"
 
 interface Model {
   selectedUrls: string[]
@@ -33,7 +33,7 @@ export interface ClearShelf extends Message {
   type: "ClearShelf"
 }
 
-type WidgetMessage = ClearShelf
+type WidgetMessage = ClearShelf | SendShelfContents
 type InboundMessage = FullyFormedMessage<
   WidgetMessage | AddToShelf | SendShelfContents
 >
@@ -87,19 +87,18 @@ class Shelf extends React.Component<Widget.Props<Model, WidgetMessage>> {
     }
   }
 
+  // FIXME: logic through react component - not cool
+  componentDidUpdate() {
+    if (!this.props.doc.selectedUrls.length) return
+
+    this.props.emit({
+      type: "SendShelfContents",
+      body: { recipientUrl: Content.rootBoardUrl },
+    })
+  }
+
   render() {
-    const { selectedUrls } = this.props.doc
-    const count = selectedUrls.length
-
-    if (count <= 0) return null
-
-    return (
-      <div style={style.Shelf}>
-        {selectedUrls.map((url, idx) => (
-          <ShelfCard key={idx} url={url} index={idx} />
-        ))}
-      </div>
-    )
+    return null
   }
 }
 

--- a/src/components/SidecarApp.tsx
+++ b/src/components/SidecarApp.tsx
@@ -66,13 +66,25 @@ export default class SidecarApp extends React.Component<{}, State> {
       case "ready":
         if (!workspaceUrl) return null
         return (
-          <Content
-            mode="fullscreen"
-            type="SidecarWorkspace"
-            url={workspaceUrl}
-          />
+          <div>
+            <Content
+              mode="fullscreen"
+              type="SidecarWorkspace"
+              url={workspaceUrl}
+            />
+            <button onClick={this.onResetWorkspaceUrl}>
+              Reset Workspace URL
+            </button>
+          </div>
         )
     }
+  }
+
+  onResetWorkspaceUrl = () => {
+    this.setState({
+      mode: "setup",
+      workspaceUrl: undefined,
+    })
   }
 
   onUrlChange = (event: any) => {

--- a/src/components/SidecarUploader.tsx
+++ b/src/components/SidecarUploader.tsx
@@ -79,6 +79,7 @@ export default class SidecarUploader extends React.Component<Props, State> {
 
   importData(dataTransfer: DataTransfer) {
     const urlPromises = DataImport.importData(dataTransfer)
+
     Promise.all(urlPromises).then(urls => {
       this.props.change(doc => {
         doc.selectedUrls = doc.selectedUrls.concat(urls)
@@ -93,7 +94,7 @@ Widget.create("SidecarUploader", SidecarUploader, SidecarUploader.reify)
 const style = {
   SidecarUploader: {
     position: "absolute" as "absolute",
-    top: 0,
+    top: 30,
     right: 0,
     bottom: 0,
     left: 0,

--- a/src/data/Store.ts
+++ b/src/data/Store.ts
@@ -89,7 +89,7 @@ export default class Store {
     return handle
   }
 
-  clipper(): Rx.Observable<any> {
+  clipper(): Rx.Observable<Msg.Clipper | null> {
     return this.clipper$
   }
 


### PR DESCRIPTION
This makes sidecard uploads go straight to root board, it's ready to review, but I'm not happy with it; first of all - the logic is implemented inside of react component, I think it would be cleaner if we could have an actor without a widget, and also, if actors could listen to changes made docs (I probably lack enough automerge knowledge to know if this is viable). I'm also not sure about "shelf 2.0" and if this work is somehow not aligned with that. But I wanted to drop some stuff from my laptop to capstone, and this seemed like simpler way than emailing myself, and ctrl-c + ctrl-v into capstone on pixelbook.