### PR TITLE
Fix resize behavior of embedded board cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-portal": "^4.1.5",
     "react-transition-group": "^2.5.0",
     "react-with-available-width": "^2.0.0",
-    "resize-observer-polyfill": "^1.5.0",
     "rxjs": "^6.3.2",
     "stats.js": "^0.17.0",
     "tap-browser-el": "^2.0.0",

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -19,7 +19,6 @@ import Ink, { InkStroke } from "./Ink"
 import { AddToShelf, ShelfContents, ShelfContentsRequested } from "./Shelf"
 import * as SizeUtils from "../logic/SizeUtils"
 import * as css from "./css/Board.css"
-import ResizeObserver from "resize-observer-polyfill"
 
 const withAvailableWidth = require("react-with-available-width")
 const boardIcon = require("../assets/board_icon.svg")

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -30,4 +30,24 @@ declare global {
     // Fix for incorrect TS built-in type
     [Symbol.iterator](): IterableIterator<DataTransferItem>
   }
+
+  interface ResizeObserverCallback {
+    (entries: ResizeObserverEntry[], observer: ResizeObserver): void
+  }
+
+  interface ResizeObserverEntry {
+    readonly target: Element
+    readonly contentRect: DOMRectReadOnly
+  }
+
+  interface ResizeObserver {
+    observe(target: Element): void
+    unobserve(target: Element): void
+    disconnect(): void
+  }
+
+  declare var ResizeObserver: {
+    prototype: ResizeObserver
+    new (callback: ResizeObserverCallback): ResizeObserver
+  }
 }


### PR DESCRIPTION
Turns out all we needed is an observer for the `withAvailableWidth` wrapper and the board automatically gets re-render calls on resize and scales all it's contents correctly \o/