### PR TITLE
[POC] end-user-programming "REPL" exploration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
+    "@types/node-localstorage": "^1.3.0",
     "automerge": "^0.9.1",
     "browser-process-hrtime": "^0.1.2",
     "bs58": "^4.0.1",
@@ -68,8 +69,10 @@
     "hypercore-archiver": "^4.6.0",
     "hyperdiscovery": "^8.0.0",
     "js-crc": "^0.2.0",
+    "json-fn": "^1.1.1",
     "lodash": "^4.17.10",
     "micromatch": "^3.1.10",
+    "node-localstorage": "^1.3.1",
     "random-access-chrome-file": "^1.1.1",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",

--- a/src/apps/repl/.gitignore
+++ b/src/apps/repl/.gitignore
@@ -1,0 +1,2 @@
+.cache
+default

--- a/src/apps/repl/repl
+++ b/src/apps/repl/repl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+../../../node_modules/.bin/cross-env TS_NODE_FILES=1 TS_NODE_CACHE_DIRECTORY=.cache TS_NODE_SKIP_IGNORE=1 node -r ts-node/register ./repl.ts $@

--- a/src/apps/repl/repl.ts
+++ b/src/apps/repl/repl.ts
@@ -1,0 +1,105 @@
+import { LocalStorage } from "node-localstorage"
+
+interface Global {
+  localStorage: LocalStorage
+}
+
+declare var global: Global
+
+global.localStorage = new LocalStorage("./localstorage")
+
+const raf = require("random-access-file")
+import * as Link from "capstone/Link"
+import * as Peek from "../../data/Peek"
+import * as Workspace from "../../plugins/Workspace"
+import * as repl from "repl"
+import CloudClient from "discovery-cloud/Client"
+import Content from "capstone/Content"
+import Handle from "capstone/Handle"
+import { Model as REPLModel } from "capstone/REPL"
+import Store from "capstone/Store"
+import StoreBackend from "capstone/StoreBackend"
+import { Doc } from "automerge/frontend"
+import { Hypermerge } from "hypermerge"
+import { last } from "lodash"
+import { parse } from "json-fn"
+
+const workspaceUrl = process.argv[2]
+
+const DEBUG = false
+
+const hm = new Hypermerge({ storage: raf })
+const storeBackend = new StoreBackend(hm)
+Content.store = new Store()
+
+storeBackend.sendQueue.subscribe(msg => {
+  if (DEBUG) {
+    console.log("backend msg", msg)
+  }
+  Content.store.onMessage(msg)
+})
+
+Content.store.sendQueue.subscribe(msg => {
+  if (DEBUG) {
+    console.log("frontend msg", msg)
+  }
+  storeBackend.onMessage(msg)
+})
+
+hm.joinSwarm(
+  new CloudClient({
+    url: "wss://discovery-cloud.herokuapp.com",
+    // url: "ws://localhost:8080",
+    id: hm.id,
+    stream: hm.stream,
+  }),
+)
+
+const startRepl = (replUrl: string) => {
+  repl.start({
+    prompt: ">>> ",
+    eval: (cmd: string, context: any, filename: string, callback: Function) => {
+      if (!cmd || !cmd.length) {
+        callback()
+      }
+
+      const handle = Content.open<REPLModel>(replUrl)
+
+      handle.change(doc => {
+        if (!doc.commands) {
+          doc.commands = [{ code: cmd }]
+        } else {
+          doc.commands.push({ code: cmd })
+        }
+
+        return doc
+      })
+
+      handle.subscribe(doc => {
+        const lastCmd = last(doc.commands)
+        if (!lastCmd) return
+
+        const { result } = lastCmd as { result: string }
+        if (!result) return
+
+        const parsed = parse(result)
+
+        handle.close()
+
+        callback(parsed.error, parsed.result)
+      })
+    },
+  })
+}
+
+hm.ready.then(hm => {
+  if (DEBUG) {
+    Peek.enable()
+  }
+
+  Content.once<Workspace.Model>(workspaceUrl, workspace => {
+    console.log(`Welcome to Capstone REPL! (${workspace.replUrl})`)
+
+    setTimeout(() => startRepl(workspace.replUrl), 10)
+  })
+})

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,10 +5,14 @@ import { Content } from "capstone"
 import Stats from "./Stats"
 import * as Debug from "debug"
 import * as css from "./css/App.css"
+import * as Board from "../plugins/Board"
+import * as UUID from "capstone/UUID"
 
 import "../plugins"
 
 const log = Debug("component:app")
+
+window.hooks = {}
 
 type State = {
   url?: string
@@ -24,6 +28,24 @@ export default class App extends React.Component<State> {
     this.setState({
       url: url,
       shouldHideFPSCounter: Content.store.shouldHideFPSCounter(),
+    })
+
+    Content.once(url, workspace => {
+      if (!workspace.rootUrl) return
+
+      Content.change<Board.Model>(workspace.rootUrl as string, rootBoard => {
+        const id = UUID.create()
+
+        rootBoard.cards[id] = {
+          id,
+          url: workspace.replUrl as string,
+          x: 100,
+          y: 100,
+          z: 1,
+          width: 300,
+          height: 500,
+        }
+      })
     })
 
     setTimeout(() => {

--- a/src/node_modules/capstone/Env.ts
+++ b/src/node_modules/capstone/Env.ts
@@ -1,5 +1,13 @@
 import { defaults } from "lodash"
 
+declare global {
+  namespace NodeJS {
+    interface Global {
+      navigator: any
+    }
+  }
+}
+
 export interface Env {
   isTouchscreen: boolean
   device: "capstone" | "sidecar"
@@ -7,8 +15,12 @@ export interface Env {
 
 export function defaultEnv(): Env {
   return {
-    isTouchscreen: navigator.maxTouchPoints > 0,
-    device: navigator.userAgent.includes("CrOS") ? "capstone" : "sidecar",
+    isTouchscreen: global.navigator ? navigator.maxTouchPoints > 0 : false,
+    device: global.navigator
+      ? navigator.userAgent.includes("CrOS")
+        ? "capstone"
+        : "sidecar"
+      : "sidecar",
   }
 }
 

--- a/src/node_modules/capstone/REPL.tsx
+++ b/src/node_modules/capstone/REPL.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+import * as Widget from "./Widget"
+import { AnyDoc } from "automerge/frontend"
+import * as Reify from "./Reify"
+import { stringify, parse } from "json-fn"
+
+import * as Debug from "debug"
+const log = Debug("component:repl")
+
+type Command = {
+  code: string
+  result?: string
+}
+
+export interface Model {
+  commands: Command[]
+}
+
+interface Props extends Widget.Props<Model> {}
+
+class REPL extends React.Component<Props> {
+  static reify(doc: AnyDoc): Model {
+    return {
+      commands: Reify.array(doc.commands),
+    }
+  }
+
+  componentDidMount() {
+    this.runREPL()
+  }
+
+  componentDidUpdate() {
+    this.runREPL()
+  }
+
+  runREPL = () => {
+    const commands = this.props.doc.commands || []
+
+    if (commands.every(({ result }) => result !== undefined)) {
+      return
+    }
+
+    log("commands", commands)
+
+    this.props.change(doc => {
+      const commands = doc.commands || []
+
+      doc.commands.forEach((command, i) => {
+        // skip already executed
+        if (command.result) return
+
+        let result
+        let error
+        let str
+
+        try {
+          result = eval(`(function() { return ${command.code}; })()`)
+        } catch (e) {
+          error = e.toString()
+        }
+
+        try {
+          str = stringify({ result, error })
+        } catch (e) {
+          error = e.toString()
+        }
+
+        if (str) {
+          doc.commands[i].result = str
+        } else {
+          doc.commands[i].result = stringify({ error })
+        }
+      })
+
+      return doc
+    })
+  }
+
+  render() {
+    const commands = this.props.doc.commands || []
+
+    return (
+      <div style={{ padding: 20, overflow: "hidden", height: "100%" }}>
+        <h3>REPL</h3>
+
+        <div>
+          {commands.map(command => {
+            const { result, error } = command.result
+              ? parse(command.result)
+              : { error: undefined, result: undefined }
+
+            let resultStr
+
+            try {
+              resultStr = JSON.stringify(result, null, 2)
+            } catch {
+              resultStr = stringify(result)
+            }
+
+            return (
+              <div style={{ borderBottom: "1px solid #ddd" }}>
+                <pre>>>> {command.code}</pre>
+                {error && <pre style={{ color: "red" }}>{error}</pre>}
+                {!error && resultStr && <pre>{resultStr}</pre>}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Widget.create("REPL", REPL, REPL.reify)

--- a/src/node_modules/capstone/Store.ts
+++ b/src/node_modules/capstone/Store.ts
@@ -8,9 +8,9 @@ import Queue from "./Queue"
 import { FrontendManager } from "hypermerge/frontend"
 
 const log = Debug("store:front")
-;(window as any).peek = () => {
-  console.log("please use peek() on the backend console")
-}
+// ;(window as any).peek = () => {
+//   console.log("please use peek() on the backend console")
+// }
 
 export type Activity = Msg.UploadActivity | Msg.DownloadActivity
 

--- a/src/node_modules/capstone/index.ts
+++ b/src/node_modules/capstone/index.ts
@@ -7,6 +7,7 @@ import * as Reify from "./Reify"
 import * as SizeUtils from "./SizeUtils"
 import * as UUID from "./UUID"
 import * as Widget from "./Widget"
+import * as REPL from "./REPL"
 import Content from "./Content"
 import Handler from "./Handler"
 import Queue from "./Queue"
@@ -26,4 +27,5 @@ export {
   Store,
   UUID,
   Widget,
+  REPL,
 }

--- a/src/node_modules/gps/Interactable.tsx
+++ b/src/node_modules/gps/Interactable.tsx
@@ -66,12 +66,15 @@ export default class Interactable extends React.Component<
   }
 
   componentWillReceiveProps(nextProps: InteractableProps) {
+      console.log({ nextProps })
+
     // Set x/y if position has changed
     if (
-      nextProps.position &&
-      (!this.props.position ||
-        nextProps.position.x !== this.props.position.x ||
-        nextProps.position.y !== this.props.position.y)
+      nextProps.position
+      // &&
+      // (!this.props.position ||
+        // nextProps.position.x !== this.props.position.x ||
+        // nextProps.position.y !== this.props.position.y)
     ) {
       this.setState({ position: nextProps.position })
       this.dragger && this.dragger.setPosition(nextProps.position)

--- a/src/plugins/Board/index.tsx
+++ b/src/plugins/Board/index.tsx
@@ -161,6 +161,12 @@ class Board extends React.Component<Props> {
       card.x = x
       card.y = y
       card.z = ++doc.topZ
+
+      if (window.hooks.onCardDragEnded) {
+        console.log("HOOK!")
+        window.hooks.onCardDragEnded(card)
+        console.log("AFTER", card)
+      }
     })
   }
 
@@ -252,6 +258,7 @@ class Board extends React.Component<Props> {
           <div
             data-container
             className={css.Board}
+            id="Board"
             ref={this.onRef}
             onDragOver={this.onDragOver}
             onDrop={this.onDrop}
@@ -328,7 +335,7 @@ class Board extends React.Component<Props> {
         }
 
         return (
-          <div className={css.Board} ref={this.onRef}>
+          <div className={css.Board} ref={this.onRef} id="Board">
             <Ink
               onInkStroke={this.onInkStroke}
               strokes={strokes}
@@ -355,7 +362,7 @@ class Board extends React.Component<Props> {
       case "preview": {
         return (
           <div>
-            <div className={css.Board} />
+            <div className={css.Board} id="Board" />
             <div className={css.FrostedGlass} />
           </div>
         )

--- a/src/plugins/Workspace/index.tsx
+++ b/src/plugins/Workspace/index.tsx
@@ -16,6 +16,7 @@ import ZoomNav, { NavEntry } from "./ZoomNav"
 export interface Model {
   navStack: NavEntry[]
   rootUrl: string
+  replUrl: string
   shelfUrl: string
   shelfOffset: number
 }
@@ -55,6 +56,7 @@ class Workspace extends React.Component<Widget.Props<Model, WidgetMessage>> {
     return {
       navStack: Reify.array(doc.navStack),
       rootUrl: Reify.string(doc.rootUrl),
+      replUrl: Reify.string(doc.replUrl),
       shelfUrl: Reify.link(doc.shelfUrl),
       shelfOffset: Reify.number(doc.shelfOffset),
     }
@@ -64,6 +66,7 @@ class Workspace extends React.Component<Widget.Props<Model, WidgetMessage>> {
     return {
       navStack: [],
       rootUrl: Content.create("Board"),
+      replUrl: Content.create("REPL"),
       shelfUrl: Content.create("Board"),
       shelfOffset: -200,
     }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,10 +1,15 @@
 import { Content, Msg } from "capstone"
 
+interface Hooks {
+  onCardDragEnded?: Function
+}
+
 declare global {
   interface Window {
     Content: typeof Content
     visualViewport: VisualViewport
     requestIdleCallback: (cb: () => void, options?: { timeout: number }) => void
+    hooks: Hooks
   }
 
   interface PointerEvent {

--- a/src/types/json-fn.d.ts
+++ b/src/types/json-fn.d.ts
@@ -1,0 +1,5 @@
+declare module 'json-fn' {
+  export function clone(obj: any, date2obj?: boolean): any;
+  export function stringify(obj: any): string;
+  export function parse(str: string, date2obj?: boolean): any;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,13 @@
   dependencies:
     "@types/braces" "*"
 
+"@types/node-localstorage@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node-localstorage/-/node-localstorage-1.3.0.tgz#8341b89abd8ad00afcd3fa9242ed956b8f5ad32c"
+  integrity sha512-9+s5CWGhkYitklhLgnbf4s5ncCEx0An2jhBuhvw/sh9WNQ+/WvNFkPLyLjXGy+Oeo8CjPl69oz6M2FzZH+KwWA==
+  dependencies:
+    "@types/events" "*"
+
 "@types/node@*":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
@@ -2860,6 +2867,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-fn@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-fn/-/json-fn-1.1.1.tgz#4293c9198a482d6697d334a6e32cd0d221121e80"
+  integrity sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA=
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -3491,6 +3503,13 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
+
+node-localstorage@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-1.3.1.tgz#3177ef42837f398aee5dd75e319b281e40704243"
+  integrity sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==
+  dependencies:
+    write-file-atomic "^1.1.4"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -4714,6 +4733,11 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -5604,6 +5628,15 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  integrity sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
This PR is proof-of-concept for REPL for connecting from laptop sidecar machine to running capstone instance.

Basic running: install, restart capstone, and then (on sidecar machine):

```bash
$ cd src/apps/repl-cli
$ ./capstone-cli "capstone://Workspace/..." # grab the workspace from running capstone instance

Welcome to Capstone CLI [hash]
>>>
```

You can now execute one-off commands within the Capstone env:

```
# not too exciting
>>> 2 + 2
4

# dump the current store state
>>> Content.store
{ ... }

# snap all cards to grid
>>> Content.once(Content.rootBoardUrl, change => change(doc => {
    Object.keys(doc.cards).forEach(key => {
      const snap = 100
      doc.cards[key].x = Math.round(doc.cards[key].x / snap) * snap
      doc.cards[key].y = Math.round(doc.cards[key].y / snap) * snap
    })

    return doc
  })
)
```

I'm also experimenting with idea of `hooks` to attach behaviours, the only existing hook right now is `hooks.onCardDragEnded` but this allows us to have snap-to-grid happen after each drag is completed (hook is execute within `doc.change` context so we can update card directly):

```
>>> hooks.onCardDragEnded = (card) => {
  const snap = 100
  card.x = Math.round(card.x / snap) * snap
  card.y = Math.round(card.y / snap) * snap
}
```

Putting this out so you can play with it before Friday's show&tell where I hope to demo this functionality and share some notes. 

_This probably shouldn't be merged._